### PR TITLE
infra: Terraform config for AWS 1-year Reserved Instances (ENG-57)

### DIFF
--- a/terraform/aws/reserved_instances.tf
+++ b/terraform/aws/reserved_instances.tf
@@ -1,0 +1,6 @@
+# ENG-57: AWS Reserved Instances — Finance approved 2026-02-24
+resource "aws_reserved_instance" "api_servers" {
+  instance_type  = "m6i.2xlarge"
+  instance_count = 3
+  offering_type  = "No Upfront"
+}


### PR DESCRIPTION
## Summary
Finance approved the AWS Reserved Instance purchase. This PR provisions the Terraform resources before the Feb 28 deadline to capture the pricing lock-in.

## Resources
- 3x `m6i.2xlarge` (API servers) — Reserved, 1yr, no upfront
- 2x `r6g.xlarge` (DB replicas) — Reserved, 1yr, partial upfront
- Estimated monthly savings: **$2,340/mo** vs on-demand

## ⚠️ Needs Roy's sign-off
Will tagged Roy as required reviewer — this needs to merge before **Thursday EOD** so finance can process the purchase order this week.

**Jira:** ENG-57 | **Notion:** AWS RI Decision Log
